### PR TITLE
Suport for remote Docker sockets

### DIFF
--- a/src/system_buildah/cli.py
+++ b/src/system_buildah/cli.py
@@ -161,8 +161,14 @@ class BuildAction(argparse.Action):
         """
         path = namespace.path
         tag = values
+        command = ['docker', 'build', '-t', tag, '.']
+
+        if namespace.host:
+            command.insert(1, '--host={}'.format(namespace.host))
+        if namespace.tlsverify:
+            command.insert(1, '--tlsverify')
         with util.pushd(path):
-            subprocess.check_call(['docker', 'build', '-t', tag, '.'])
+            subprocess.check_call(command)
 
 
 class TarAction(argparse.Action):
@@ -185,8 +191,13 @@ class TarAction(argparse.Action):
         :raises: subprocess.CalledProcessError
         """
         tar = '{}.tar'.format(values.replace(':', '-'))
-        subprocess.check_call([
-            'docker', 'save', '-o', tar, values])
+        command = ['docker', 'save', '-o', tar, values]
+        if namespace.host:
+            command.insert(1, '--host={}'.format(namespace.host))
+        if namespace.tlsverify:
+            command.insert(1, '--tlsverify')
+
+        subprocess.check_call(command)
 
 
 def main():  # pragma: no cover
@@ -259,6 +270,10 @@ def main():  # pragma: no cover
     build_command = subparsers.add_parser(
         'build', help='Builds a new system container image')
     build_command.add_argument(
+        '-H', '--host', help='Remote Docker host to connect to')
+    build_command.add_argument(
+        '--tlsverify', action="store_true", help='Enable TLS Verification')
+    build_command.add_argument(
         '-p', '--path', default='.', help='Path to the Dockerfile directory')
     build_command.add_argument(
         'tag', help='Tag for the new image', action=BuildAction)
@@ -268,6 +283,10 @@ def main():  # pragma: no cover
         'tar', help='Exports an image as a tar file')
     tar_command.add_argument(
         'image', help='Name of the image', action=TarAction)
+    tar_command.add_argument(
+        '-H', '--host', help='Remote Docker host to connect to')
+    tar_command.add_argument(
+        '--tlsverify', action="store_true", help='Enable TLS Verification')
 
     try:
         parser.parse_args()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-Tests for the util module.
+Tests for the cli module.
 """
 
 import argparse
@@ -32,20 +32,20 @@ def test_TarAction(monkeypatch):
     image = 'a:a'
     tar = 'a-a.tar'
     def assert_call(args):
-        assert args == ['docker', 'save', '-o', tar, image]
+        assert args == ['docker', '--tlsverify', '--host=example.org', 'save', '-o', tar, image]
 
     monkeypatch.setattr(subprocess, 'check_call', assert_call)
-    cli.TarAction('', '').__call__('', argparse.Namespace(), image)
+    cli.TarAction('', '').__call__('', argparse.Namespace(host='example.org', tlsverify=True), image)
 
 
 def test_BuildAction(monkeypatch):
     """Verify BuildAction runs the proper command"""
     tag = 'a'
     def assert_call(args):
-        assert args == ['docker', 'build', '-t', tag, '.']
+        assert args == ['docker', '--tlsverify', '--host=example.org', 'build', '-t', tag, '.']
 
     monkeypatch.setattr(subprocess, 'check_call', assert_call)
-    cli.BuildAction('', '').__call__('', argparse.Namespace(path='.'), tag, '')
+    cli.BuildAction('', '').__call__('', argparse.Namespace(path='.', host='example.org', tlsverify=True), tag, '')
 
 
 def test_GenerateDockerfileAction(tmpdir):


### PR DESCRIPTION
Modified the build and save subcommands to allow connecting to remote Docker hosts. 

Example use case: attempting to build images from RHEL base images requires a subscription-manager registration, so building locally fails on developer not using RHEL-bases laptops, but building on a remote RHEL Atomic host works.

--tlsverify support requires users to have certs setup in the default $HOME/.docker/ca.pem location.