### PR TITLE
0.1.0 and buildah tar update

### DIFF
--- a/contrib/rpm/system-buildah.spec
+++ b/contrib/rpm/system-buildah.spec
@@ -1,11 +1,11 @@
 Name:           system-buildah
-Version:        0.0.9
+Version:        0.1.0
 Release:        1%{?dist}
 Summary:        Simple toolbox for building system containers
 
 License:        GPLv3+
-URL:            https://github.com/ashcrow/system-buildah/
-Source0:        https://github.com/ashcrow/system-buildah/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+URL:            https://github.com/projectatomic/system-buildah/
+Source0:        https://github.com/projectatomic/system-buildah/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python3-devel, python3-setuptools
@@ -38,6 +38,9 @@ sed -i 's|/usr/bin/env python|/usr/bin/python3|' $RPM_BUILD_ROOT%{python3_siteli
 
 
 %changelog
+* Fri Feb 23 2018 Steve Milner <smilner@redhat.com> - 0.1.0-1
+- buildah tar update
+
 * Mon Feb  5 2018 Steve Milner <smilner@redhat.com> - 0.0.9-1
 - Code reorganization
 

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,10 @@ test_require = extract_requirements('test-requirements.txt')
 
 setup(
     name='system-buildah',
-    version='0.0.9',
+    version='0.1.0',
     description='Simple System Image build toolbox',
     author='Steve Milner',
-    url='https://github.com/ashcrow/system-buildah',
+    url='https://github.com/projectatomic/system-buildah',
     license="GPLv3+",
 
     install_requires=install_requires,

--- a/src/system_buildah/__init__.py
+++ b/src/system_buildah/__init__.py
@@ -16,4 +16,4 @@
 system_buildah package
 """
 
-__version__ = '0.0.9'
+__version__ = '0.1.0'

--- a/test/test_managers.py
+++ b/test/test_managers.py
@@ -78,25 +78,23 @@ def test_BuildahManager_tar(monkeypatch):
     Test the Buildah manager tar command.
     """
     bm = BuildahManager()
-    output = 'output'
+    output = 'output:latest'
 
     def assert_call(arg):
         # First call is a buildah push
         if arg[0] == 'buildah':
             assert arg[0:3] == ['buildah', 'push', output]
-        # Second call is to the systems tar command
-        elif arg[0] == 'tar':
-            assert arg == ['tar', '-cf', '{}.tar'.format(output), output]
         # Anything else is totally unexpected
         else:
             pytest.fail(
                 'Unexpected input to subprocess.check_call: {}'.format(arg))
 
-    def assert_mkdir(d):
-        assert d == output
+    def assert_rename(src, dest):
+        assert src == 'output'
+        assert dest == 'output-latest.tar'
 
-    monkeypatch.setattr(util, 'mkdir', assert_mkdir)
     monkeypatch.setattr(subprocess, 'check_call', assert_call)
+    monkeypatch.setattr(os, 'rename', assert_rename)
     bm.tar(argparse.Namespace(host=None, tlsverify=None), output)
 
 


### PR DESCRIPTION
- Update to use ``docker-archive`` transport in tar commend when using the buildah manager
- Update to point to projectatomic github namespace
- tag for ``0.1.0``